### PR TITLE
feat(licenses): add additional license details including next payment…

### DIFF
--- a/src/app/admin/licenses/page.tsx
+++ b/src/app/admin/licenses/page.tsx
@@ -119,6 +119,18 @@ export default function LicensesPage() {
                                         <span className="font-semibold text-gray-900">Expiration :</span>
                                         <span className="text-gray-600 ml-1">{new Date(licence.expiration).toLocaleDateString()}</span>
                                     </p>
+                                    <p className="mb-1 text-sm">
+                                        <span className="font-semibold text-gray-900">Prochain payement :</span>
+                                        <span className="text-gray-600 ml-1">{new Date(licence.stripe.next_payment_at).toLocaleDateString()}</span>
+                                    </p>
+                                    <p className="mb-1 text-sm">
+                                        <span className="font-semibold text-gray-900">Montant :</span>
+                                        <span className="text-gray-600 ml-1">{(licence.stripe.price_amount / 100).toFixed(2)}€</span>
+                                    </p>
+                                    <p className="mb-1 text-sm">
+                                        <span className="font-semibold text-gray-900">Intervalle de facturation :</span>
+                                        <span className="text-gray-600 ml-1">{licence.stripe.price_interval}</span>
+                                    </p>
 
                                     <p className="">
                                         <span className="font-semibold text-sm text-gray-900">Statut :</span>

--- a/src/lib/getLicenses.ts
+++ b/src/lib/getLicenses.ts
@@ -5,6 +5,11 @@ export type License = {
     licence_id: string,
     account_id: string,
     expiration: string,
+    stripe: {
+        next_payment_at: string,
+        price_amount: number,
+        price_interval: string,
+    }
     store: {
         name: string,
     } | null,


### PR DESCRIPTION
This pull request enhances the license administration page by displaying additional Stripe billing details for each license. It also updates the license data type to include these new Stripe-related fields.

**Licenses page improvements:**

* Added display of the next Stripe payment date, payment amount (in euros), and billing interval for each license in the `LicensesPage` component.

**Data model updates:**

* Updated the `License` type in `getLicenses.ts` to include a nested `stripe` object with `next_payment_at`, `price_amount`, and `price_interval` fields.…, amount, and billing interval