### PR TITLE
 integrate catalogId into category management functions

### DIFF
--- a/src/app/admin/shop/[shopId]/catalogue/CatalogueClient.tsx
+++ b/src/app/admin/shop/[shopId]/catalogue/CatalogueClient.tsx
@@ -76,10 +76,12 @@ export default function CatalogueClient({
     categories,
     items,
     storeId,
+    catalogId,
 }: {
     categories: Categorie[];
     items: Item[];
     storeId: number;
+    catalogId: number;
 }) {
     const [activeTab, setActiveTab] = useState<Tab>("categories");
     const [selectedCategoryId, setSelectedCategoryId] = useState<number | null>(null);
@@ -129,6 +131,7 @@ export default function CatalogueClient({
                             items={items.filter((i) => i.categorie_id === selectedCategoryId)}
                             categories={categories}
                             storeId={storeId}
+                            catalogId={catalogId}
                             onBack={() => setSelectedCategoryId(null)}
                         />
                     ) : (
@@ -136,6 +139,7 @@ export default function CatalogueClient({
                             categories={categories}
                             items={items}
                             storeId={storeId}
+                            catalogId={catalogId}
                             onDrillDown={setSelectedCategoryId}
                         />
                     )
@@ -153,11 +157,13 @@ function CategoriesSection({
     categories,
     items,
     storeId,
+    catalogId,
     onDrillDown,
 }: {
     categories: Categorie[];
     items: Item[];
     storeId: number;
+    catalogId: number;
     onDrillDown: (id: number) => void;
 }) {
     const router = useRouter();
@@ -195,7 +201,7 @@ function CategoriesSection({
         if (!addType.trim()) return;
         setLoading(true);
         try {
-            await createCategorie(storeId, { type: addType.trim() });
+            await createCategorie(storeId, catalogId, { type: addType.trim() });
             toast.success("Catégorie créée");
             close();
             router.refresh();
@@ -208,7 +214,7 @@ function CategoriesSection({
         if (!editType.trim()) return;
         setLoading(true);
         try {
-            await updateCategorie(panel.categorie.categorie_id, storeId, { type: editType.trim() });
+            await updateCategorie(panel.categorie.categorie_id, storeId, catalogId, { type: editType.trim() });
             toast.success("Catégorie mise à jour");
             close();
             router.refresh();
@@ -227,7 +233,7 @@ function CategoriesSection({
         }
         setLoading(true);
         try {
-            await deleteCategorie(panel.categorie.categorie_id, storeId);
+            await deleteCategorie(panel.categorie.categorie_id, storeId, catalogId);
             toast.success("Catégorie supprimée");
             close();
             router.refresh();
@@ -405,12 +411,14 @@ function CategoryDrillDown({
     items,
     categories,
     storeId,
+    catalogId,
     onBack,
 }: {
     category: CatWithMeta;
     items: Item[];
     categories: Categorie[];
     storeId: number;
+    catalogId: number;
     onBack: () => void;
 }) {
     const router = useRouter();

--- a/src/app/admin/shop/[shopId]/catalogue/page.tsx
+++ b/src/app/admin/shop/[shopId]/catalogue/page.tsx
@@ -1,3 +1,4 @@
+import getCatalogs from "@/lib/getCatalogs";
 import getCategories, { Categorie } from "@/lib/getCategories";
 import getItems, { Item } from "@/lib/getItems";
 import CatalogueClient from "./CatalogueClient";
@@ -12,11 +13,14 @@ export default async function CataloguePage({
 
     let categories: Categorie[] = [];
     let items: Item[] = [];
+    let catalogId: number = 0;
     let error: string | null = null;
 
     try {
+        const catalogs = await getCatalogs(storeId);
+        catalogId = catalogs[0]?.catalog_id ?? 0;
         [categories, items] = await Promise.all([
-            getCategories(storeId),
+            catalogId ? getCategories(storeId, catalogId) : Promise.resolve([]),
             getItems(storeId),
         ]);
     } catch (e: unknown) {
@@ -30,7 +34,7 @@ export default async function CataloguePage({
                     Erreur : {error}
                 </div>
             ) : (
-                <CatalogueClient categories={categories} items={items} storeId={storeId} />
+                <CatalogueClient categories={categories} items={items} storeId={storeId} catalogId={catalogId} />
             )}
         </div>
     );

--- a/src/lib/createCategorie.ts
+++ b/src/lib/createCategorie.ts
@@ -4,6 +4,7 @@ import { Categorie } from "./getCategories";
 
 export default async function createCategorie(
     storeId: number,
+    catalogId: number,
     data: { type: string }
 ): Promise<Categorie> {
     const cookieStore = await cookies();
@@ -13,7 +14,7 @@ export default async function createCategorie(
         throw new Error("Unauthorized: missing profile token");
     }
 
-    const res = await fetch(`${process.env.BACKEND_GO}/categorie`, {
+    const res = await fetch(`${process.env.BACKEND_GO}/categorie/catalog/${catalogId}`, {
         method: "POST",
         headers: {
             "Content-Type": "application/json",

--- a/src/lib/deleteCategorie.ts
+++ b/src/lib/deleteCategorie.ts
@@ -3,7 +3,8 @@ import { cookies } from "next/headers";
 
 export default async function deleteCategorie(
     categorieId: number,
-    storeId: number
+    storeId: number,
+    catalogId: number
 ): Promise<void> {
     const cookieStore = await cookies();
     const profileToken = cookieStore.get(`profile_token_${storeId}`)?.value;
@@ -12,7 +13,7 @@ export default async function deleteCategorie(
         throw new Error("Unauthorized: missing profile token");
     }
 
-    const res = await fetch(`${process.env.BACKEND_GO}/categorie/${categorieId}`, {
+    const res = await fetch(`${process.env.BACKEND_GO}/categorie/catalog/${catalogId}/${categorieId}`, {
         method: "DELETE",
         headers: {
             Authorization: `Bearer ${profileToken}`,

--- a/src/lib/getCatalogs.ts
+++ b/src/lib/getCatalogs.ts
@@ -15,7 +15,7 @@ export default async function getCatalogs(storeId: number): Promise<Catalog[]> {
         throw new Error("Unauthorized: missing profile token");
     }
 
-    const res = await fetch(`${process.env.BACKEND_GO}/catalog`, {
+    const res = await fetch(`${process.env.BACKEND_GO}/catalog/store/${storeId}`, {
         headers: {
             Authorization: `Bearer ${profileToken}`,
         },

--- a/src/lib/getCategories.ts
+++ b/src/lib/getCategories.ts
@@ -6,7 +6,7 @@ export type Categorie = {
     type: string;
 };
 
-export default async function getCategories(storeId: number): Promise<Categorie[]> {
+export default async function getCategories(storeId: number, catalogId: number): Promise<Categorie[]> {
     const cookieStore = await cookies();
     const profileToken = cookieStore.get(`profile_token_${storeId}`)?.value;
 
@@ -14,7 +14,7 @@ export default async function getCategories(storeId: number): Promise<Categorie[
         throw new Error("Unauthorized: missing profile token");
     }
 
-    const res = await fetch(`${process.env.BACKEND_GO}/categorie`, {
+    const res = await fetch(`${process.env.BACKEND_GO}/categorie/catalog/${catalogId}`, {
         headers: {
             Authorization: `Bearer ${profileToken}`,
         },

--- a/src/lib/updateCategorie.ts
+++ b/src/lib/updateCategorie.ts
@@ -5,6 +5,7 @@ import { Categorie } from "./getCategories";
 export default async function updateCategorie(
     categorieId: number,
     storeId: number,
+    catalogId: number,
     data: { type: string }
 ): Promise<Categorie> {
     const cookieStore = await cookies();
@@ -14,7 +15,7 @@ export default async function updateCategorie(
         throw new Error("Unauthorized: missing profile token");
     }
 
-    const res = await fetch(`${process.env.BACKEND_GO}/categorie/${categorieId}`, {
+    const res = await fetch(`${process.env.BACKEND_GO}/categorie/catalog/${catalogId}/${categorieId}`, {
         method: "PUT",
         headers: {
             "Content-Type": "application/json",


### PR DESCRIPTION
This pull request updates the catalogue management system to support operations on categories within a specific catalog, rather than just at the store level. The main changes involve passing and handling a `catalogId` throughout the admin catalogue UI and API calls, ensuring all category CRUD operations are scoped to the selected catalog.

**Catalogue scoping and API updates:**

* Updated the catalogue admin UI (`CatalogueClient`, `CategoriesSection`, `CategoryDrillDown`) to accept and pass `catalogId` for all category-related actions and components. ([src/app/admin/shop/[shopId]/catalogue/CatalogueClient.tsxR79-R84](diffhunk://#diff-cf86cb5f6794bb1c18385c49d1431e8b49c2787b1c5eb279dcf9f97aa8207e43R79-R84), [src/app/admin/shop/[shopId]/catalogue/CatalogueClient.tsxR134-R142](diffhunk://#diff-cf86cb5f6794bb1c18385c49d1431e8b49c2787b1c5eb279dcf9f97aa8207e43R134-R142), [src/app/admin/shop/[shopId]/catalogue/CatalogueClient.tsxR160-R166](diffhunk://#diff-cf86cb5f6794bb1c18385c49d1431e8b49c2787b1c5eb279dcf9f97aa8207e43R160-R166), [src/app/admin/shop/[shopId]/catalogue/CatalogueClient.tsxR414-R421](diffhunk://#diff-cf86cb5f6794bb1c18385c49d1431e8b49c2787b1c5eb279dcf9f97aa8207e43R414-R421))
* Modified the API utility functions (`createCategorie`, `updateCategorie`, `deleteCategorie`, `getCategories`) to require and use `catalogId` in their requests, updating the backend endpoints accordingly. [[1]](diffhunk://#diff-210f70874c354439edfde620c50eb2e490b4aa97750e3d8dc5e4c752d86304acR7) [[2]](diffhunk://#diff-210f70874c354439edfde620c50eb2e490b4aa97750e3d8dc5e4c752d86304acL16-R17) [[3]](diffhunk://#diff-1cf5124bbc968a4b081e947931a02d647cac6b197cc6eca8e730f3067bd3388dR8) [[4]](diffhunk://#diff-1cf5124bbc968a4b081e947931a02d647cac6b197cc6eca8e730f3067bd3388dL17-R18) [[5]](diffhunk://#diff-66938985274d6ee860fc08f682eacdfeee24e984d15306c4bd9b8eb09c814efeL6-R7) [[6]](diffhunk://#diff-66938985274d6ee860fc08f682eacdfeee24e984d15306c4bd9b8eb09c814efeL15-R16) [[7]](diffhunk://#diff-3ea4be9dbae140192dfae2705e8948c31c8020d2ac2ff36589bd4878d2bcbb33L9-R17)
* Adjusted the `getCatalogs` function to fetch catalogs for a specific store using the correct endpoint.

**Catalogue selection logic:**

* Updated the catalogue page (`page.tsx`) to fetch the list of catalogs for a store, select the first one as the active catalog, and pass its `catalogId` to the client component and category/item fetchers. ([src/app/admin/shop/[shopId]/catalogue/page.tsxR1](diffhunk://#diff-4f543af139e0ae023417b6088cac80b6803b3cc6d5506e824ed5d6e168806f64R1), [src/app/admin/shop/[shopId]/catalogue/page.tsxR16-R23](diffhunk://#diff-4f543af139e0ae023417b6088cac80b6803b3cc6d5506e824ed5d6e168806f64R16-R23), [src/app/admin/shop/[shopId]/catalogue/page.tsxL33-R37](diffhunk://#diff-4f543af139e0ae023417b6088cac80b6803b3cc6d5506e824ed5d6e168806f64L33-R37))

**Category CRUD operations:**

* All category creation, update, and deletion actions now require a `catalogId` and are performed against catalog-scoped endpoints, ensuring categories are managed within the context of a specific catalog. ([src/app/admin/shop/[shopId]/catalogue/CatalogueClient.tsxL198-R204](diffhunk://#diff-cf86cb5f6794bb1c18385c49d1431e8b49c2787b1c5eb279dcf9f97aa8207e43L198-R204), [src/app/admin/shop/[shopId]/catalogue/CatalogueClient.tsxL211-R217](diffhunk://#diff-cf86cb5f6794bb1c18385c49d1431e8b49c2787b1c5eb279dcf9f97aa8207e43L211-R217), [src/app/admin/shop/[shopId]/catalogue/CatalogueClient.tsxL230-R236](diffhunk://#diff-cf86cb5f6794bb1c18385c49d1431e8b49c2787b1c5eb279dcf9f97aa8207e43L230-R236))

These changes ensure that all category management is properly scoped to the selected catalog, improving data integrity and aligning with backend API requirements.